### PR TITLE
fix(ueditor): 修复富文本编辑器上传图片时的 User-Agent 问题

### DIFF
--- a/asset/ueditor/php/action_wx_rich_text.php
+++ b/asset/ueditor/php/action_wx_rich_text.php
@@ -13,7 +13,8 @@ function fetchWxContent($url): bool|string
         CURLOPT_RETURNTRANSFER => 1,
         CURLOPT_SSL_VERIFYPEER => false,
         CURLOPT_SSL_VERIFYHOST => false,
-        CURLOPT_HTTPHEADER     => []
+        CURLOPT_HTTPHEADER => [],
+        CURLOPT_USERAGENT => "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36",
     );
 
     $opts[CURLOPT_URL] = $url ;


### PR DESCRIPTION
- 在 action_wx_rich_text.php 文件中添加了 CURLOPT_USERAGENT 选项
- 设置 User-Agent 为常见的浏览器标识，以避免某些服务器对未知 User-Agent 的限制