### PR TITLE
fix(asset): 添加 padding-bottom 样式重置

### DIFF
--- a/asset/ueditor/php/action_wx_rich_text.php
+++ b/asset/ueditor/php/action_wx_rich_text.php
@@ -64,6 +64,7 @@ $text .= <<<EOF
                             filter: 'unset',
                             backgound: 'auto',
                             display: 'unset',
+                            'padding-bottom': 'unset',
                        })
                        .removeClass('img_loading');
                 });


### PR DESCRIPTION
在微信富文本编辑器中添加了 padding-bottom 的样式重置，
以解决图片加载时的显示问题。