### PR TITLE
fix(WxCrawlerAction): 添加 padding-bottom 样式重置

### DIFF
--- a/src/Lib/Action/WxCrawlerAction.php
+++ b/src/Lib/Action/WxCrawlerAction.php
@@ -65,6 +65,7 @@ class WxCrawlerAction extends AAction
                             filter: 'unset',
                             backgound: 'auto',
                             display: 'unset',
+                            'padding-bottom': 'unset',
                        })
                        .removeClass('img_loading');
                 });


### PR DESCRIPTION
在微信文章爬取处理中，图片加载完成后需要重置更多的样式属性，
以确保在不同环境下图片显示的一致性。本次修改添加了对
padding-bottom 样式的 unset 处理，避免图片下方出现意外的空白间距。