### PR TITLE
feat(ueditor): add fullscreen option to iframe dialog

### DIFF
--- a/antd-components/Column/Ueditor.tsx
+++ b/antd-components/Column/Ueditor.tsx
@@ -61,7 +61,7 @@ export default class Ueditor extends Component<ColumnProps & {
                         return createScript(this.props.fieldProps.ueditorPath + '/ueditor.all.js?v=260331')
                     })
                     .then(() => {
-                        return createScript(this.props.fieldProps.ueditorPath + '/lang/zh-cn/zh-cn.js')
+                        return createScript(this.props.fieldProps.ueditorPath + '/lang/zh-cn/zh-cn.js?v=260514')
                     })
         }
 

--- a/asset/ueditor/dialogs/insertframe/insertframe.html
+++ b/asset/ueditor/dialogs/insertframe/insertframe.html
@@ -48,13 +48,14 @@
             </tr>
 
             <tr>
-                <td colspan="2"><span><var id="lang_input_alignMode"></var></span>
+                <td><span><var id="lang_input_alignMode"></var></span>
                     <select id="align">
                         <option value=""></option>
                         <option value="left"></option>
                         <option value="right"></option>
                     </select>
                 </td>
+                <td><label><span><var id="lang_input_allowfullscreen"></var></span><input type="checkbox" id="allowfullscreen"/> </label></td>
             </tr>
         </table>
 </div>
@@ -73,6 +74,7 @@
         $G("height").value = iframe.getAttribute("height") || iframe.style.height.replace("px","") ||"";
         $G("scroll").checked = (iframe.getAttribute("scrolling") == "yes") ? true : false;
         $G("frameborder").checked = (iframe.getAttribute("frameborder") == "1") ? true : false;
+        $G("allowfullscreen").checked = (iframe.getAttribute("allowfullscreen") == "1") ? true : false;
         $G("align").value = iframe.align ? iframe.align : "";
     }
     function queding(){
@@ -81,6 +83,7 @@
                 height = $G("height").value,
                 scroll = $G("scroll"),
                 frameborder = $G("frameborder"),
+                allowfullscreen = $G("allowfullscreen"),
                 float = $G("align").value,
                 newIframe = editor.document.createElement("iframe"),
                 div,
@@ -107,6 +110,7 @@
         /^[1-9]+[.]?\d*$/g.test( height ) ? newIframe.setAttribute("height",height) : "";
         scroll.checked ?  newIframe.setAttribute("scrolling","yes") : newIframe.setAttribute("scrolling","no");
         frameborder.checked ?  newIframe.setAttribute("frameborder","1",0) : newIframe.setAttribute("frameborder","0",0);
+        allowfullscreen.checked ?  newIframe.setAttribute("allowfullscreen","true",0) : newIframe.setAttribute("allowfullscreen","false",0);
         float ? newIframe.setAttribute("align",float) :  newIframe.setAttribute("align","");
         if(iframe){
             iframe.parentNode.insertBefore(newIframe,iframe);

--- a/asset/ueditor/lang/zh-cn/zh-cn.js
+++ b/asset/ueditor/lang/zh-cn/zh-cn.js
@@ -374,6 +374,7 @@ UE.I18N['zh-cn'] = {
             'lang_input_height':'高度：',
             'lang_input_isScroll':'允许滚动条：',
             'lang_input_frameborder':'显示框架边框：',
+            'lang_input_allowfullscreen': '允许全屏：',
             'lang_input_alignMode':'对齐方式：',
             'align':{title:"对齐方式", options:["默认", "左对齐", "右对齐", "居中"]}
 
@@ -562,6 +563,7 @@ UE.I18N['zh-cn'] = {
             'lang_input_height':'高度：',
             'lang_input_isScroll':'允许滚动条：',
             'lang_input_frameborder':'显示框架边框：',
+            'lang_input_allowfullscreen': '允许全屏：',
             'lang_input_alignMode':'对齐方式：',
             'align':{title:"对齐方式", options:["默认", "左对齐", "右对齐", "居中"]}
         },


### PR DESCRIPTION
Implement a checkbox in the iframe insertion dialog to allow users to enable or disable the `allowfullscreen` attribute. This includes updating the HTML template, the JavaScript logic for attribute handling, and adding the corresponding Chinese localization strings.

Also updated the language file versioning with a cache buster to ensure the latest translations are loaded.